### PR TITLE
Add timeout handling to fetch calls

### DIFF
--- a/input-app/src/services/TemplateLoader.ts
+++ b/input-app/src/services/TemplateLoader.ts
@@ -1,10 +1,24 @@
 import type { Template } from '../types/Questionnaire';
 
 export const fetchTemplate = async (departmentId: string): Promise<Template> => {
-  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/templates/${departmentId}`);
-  if (!response.ok) {
-    throw new Error('Failed to fetch template');
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch(
+      `${import.meta.env.VITE_API_BASE_URL}/templates/${departmentId}`,
+      { signal: controller.signal },
+    );
+    if (!response.ok) {
+      throw new Error('Failed to fetch template');
+    }
+    const res = (await response.json()) as { template: Template };
+    return res.template;
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      throw new Error('Fetch template request timed out');
+    }
+    throw e;
+  } finally {
+    clearTimeout(timeoutId);
   }
-  const res = (await response.json()) as { template: Template };
-  return res.template;
 };


### PR DESCRIPTION
## Summary
- set 5s timeout using AbortController for public key fetch
- add AbortController timeout when fetching questionnaire template
- handle log POST timeouts in LoggerService

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686770f67d5083238ece799fbc41f214