### PR TITLE
Add timeout helper and warn on fetch timeouts

### DIFF
--- a/input-app/src/services/EncryptionService.ts
+++ b/input-app/src/services/EncryptionService.ts
@@ -1,12 +1,10 @@
 import JSEncrypt from 'jsencrypt';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 export const fetchPublicKey = async (): Promise<string> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${import.meta.env.VITE_API_BASE_URL}${import.meta.env.VITE_KEY_ENDPOINT}`,
-      { signal: controller.signal },
     );
     if (!response.ok) {
       throw new Error('Failed to fetch public key');
@@ -15,11 +13,10 @@ export const fetchPublicKey = async (): Promise<string> => {
     return res.public_key;
   } catch (e) {
     if (e instanceof DOMException && e.name === 'AbortError') {
+      console.warn('EncryptionService: public key request timed out');
       throw new Error('Fetch public key request timed out');
     }
     throw e;
-  } finally {
-    clearTimeout(timeoutId);
   }
 };
 

--- a/input-app/src/services/LoggerService.ts
+++ b/input-app/src/services/LoggerService.ts
@@ -6,17 +6,16 @@ export interface LogData {
   errors: string[];
 }
 
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+
 export const sendLog = async (logData: LogData): Promise<void> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/logs`, {
+    const response = await fetchWithTimeout(`${import.meta.env.VITE_API_BASE_URL}/logs`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(logData),
-      signal: controller.signal,
     });
 
     if (response.status === 204) {
@@ -35,11 +34,9 @@ export const sendLog = async (logData: LogData): Promise<void> => {
     console.error('LoggerService: unexpected response when sending log');
   } catch (e) {
     if (e instanceof DOMException && e.name === 'AbortError') {
-      console.error('LoggerService: log request timed out');
+      console.warn('LoggerService: log request timed out');
     } else {
       console.error('LoggerService: failed to send log', e);
     }
-  } finally {
-    clearTimeout(timeoutId);
   }
 };

--- a/input-app/src/services/TemplateLoader.ts
+++ b/input-app/src/services/TemplateLoader.ts
@@ -1,12 +1,10 @@
 import type { Template } from '../types/Questionnaire';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 export const fetchTemplate = async (departmentId: string): Promise<Template> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${import.meta.env.VITE_API_BASE_URL}/templates/${departmentId}`,
-      { signal: controller.signal },
     );
     if (!response.ok) {
       throw new Error('Failed to fetch template');
@@ -15,10 +13,9 @@ export const fetchTemplate = async (departmentId: string): Promise<Template> => 
     return res.template;
   } catch (e) {
     if (e instanceof DOMException && e.name === 'AbortError') {
+      console.warn('TemplateLoader: template request timed out');
       throw new Error('Fetch template request timed out');
     }
     throw e;
-  } finally {
-    clearTimeout(timeoutId);
   }
 };

--- a/input-app/src/utils/fetchWithTimeout.ts
+++ b/input-app/src/utils/fetchWithTimeout.ts
@@ -1,0 +1,14 @@
+export const fetchWithTimeout = async (
+  input: RequestInfo | URL,
+  options: RequestInit = {},
+  timeout = 5000,
+): Promise<Response> => {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(input, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(id);
+  }
+};
+


### PR DESCRIPTION
## Summary
- create `fetchWithTimeout` helper for AbortController timeout logic
- update `EncryptionService.fetchPublicKey`, `TemplateLoader.fetchTemplate`, and `LoggerService.sendLog` to use the helper
- warn on timeout in each service

## Testing
- `npm --prefix input-app run lint`
- `npm --prefix input-app run build`


------
https://chatgpt.com/codex/tasks/task_e_6867738f6bcc8323a2941f89a7564528