### PR TITLE
Add env templates for frontend and backend

### DIFF
--- a/functions/local.settings.example.json
+++ b/functions/local.settings.example.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "KEY_VAULT_NAME": "your-key-vault-name"
+  }
+}

--- a/input-app/.env.example
+++ b/input-app/.env.example
@@ -1,0 +1,14 @@
+# Base URL of the backend API
+VITE_API_BASE_URL=https://example.com/api
+
+# Endpoint path to retrieve the RSA public key
+VITE_KEY_ENDPOINT=/public-key
+
+# Endpoint path to fetch templates
+VITE_TEMPLATE_ENDPOINT=/templates
+
+# Endpoint path to post log information
+VITE_LOGS_ENDPOINT=/logs
+
+# Timeout for API requests in milliseconds
+VITE_REQUEST_TIMEOUT_MS=5000

--- a/input-app/README.md
+++ b/input-app/README.md
@@ -67,3 +67,17 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Environment Variables
+
+Frontend variables are defined in `.env` (see `.env.example`).
+Backend Functions have their own `functions/local.settings.json`.
+
+### Frontend (`.env`)
+- `VITE_API_BASE_URL` - Base URL for the backend API.
+- `VITE_KEY_ENDPOINT` - Endpoint to fetch the RSA public key.
+- `VITE_TEMPLATE_ENDPOINT` - Path to questionnaire templates.
+- `VITE_LOGS_ENDPOINT` - Path to send log data.
+- `VITE_REQUEST_TIMEOUT_MS` - Timeout in milliseconds for API requests.
+
+Create your own `.env` based on this template.


### PR DESCRIPTION
## Summary
- add example `.env` for the `input-app`
- document frontend environment variables in README
- add `functions/local.settings.example.json` to show typical Azure Functions values

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68678cda7a0c8323a040daf8f994121d