### PR TITLE
Fix Vite mock API

### DIFF
--- a/input-app/vite.config.ts
+++ b/input-app/vite.config.ts
@@ -1,17 +1,27 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
-console.log('[Vite Config] Loading vite.config.ts');
+console.log('[Vite Config] Loading vite.config.ts')
+
+const mockApiPlugin = () => ({
+  name: 'mock-api',
+  configureServer(server) {
+    console.log('[Vite Config] configureServer hook called.')
+    server.middlewares.use((req, res, next) => {
+      console.log('[Mock API] Hit: ' + req.url)
+      if (req.url?.startsWith('/api/templates/')) {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ template: { id: 1, name: 'Sample' } }))
+        return
+      }
+      next()
+    })
+  },
+})
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), mockApiPlugin()],
   server: {
     port: 5174,
-    configureServer(server) {
-      server.middlewares.unshift((req, res, next) => {
-        console.log('[Mock API] Hit: ' + req.url);
-        next();
-      });
-    },
   },
-});
+})


### PR DESCRIPTION
## Summary
- register mock API middleware via a Vite plugin

## Testing
- `npm install`
- `nohup npm run dev >/tmp/dev_log.txt 2>&1 &`
- `curl -i http://localhost:5177/api/templates/1`


------
https://chatgpt.com/codex/tasks/task_e_6868858543a88323beb6b3e937d9e1be