### PR TITLE
Centralize API config usage

### DIFF
--- a/input-app/src/api/apiConfig.ts
+++ b/input-app/src/api/apiConfig.ts
@@ -1,0 +1,6 @@
+// API base configuration for the input-app frontend
+
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+export const KEY_ENDPOINT = import.meta.env.VITE_KEY_ENDPOINT || '/api/public-key';
+export const TEMPLATE_ENDPOINT = import.meta.env.VITE_TEMPLATE_ENDPOINT || '/api/templates';
+export const LOG_ENDPOINT = import.meta.env.VITE_LOGS_ENDPOINT || '/api/logs';

--- a/input-app/src/services/EncryptionService.ts
+++ b/input-app/src/services/EncryptionService.ts
@@ -1,10 +1,11 @@
 import JSEncrypt from 'jsencrypt';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+import { API_BASE_URL, KEY_ENDPOINT } from '../api/apiConfig';
 
 export const fetchPublicKey = async (): Promise<string> => {
   try {
     const response = await fetchWithTimeout(
-      `${import.meta.env.VITE_API_BASE_URL}${import.meta.env.VITE_KEY_ENDPOINT}`,
+      `${API_BASE_URL}${KEY_ENDPOINT}`,
     );
     if (!response.ok) {
       throw new Error('Failed to fetch public key');

--- a/input-app/src/services/LoggerService.ts
+++ b/input-app/src/services/LoggerService.ts
@@ -7,10 +7,11 @@ export interface LogData {
 }
 
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+import { API_BASE_URL, LOG_ENDPOINT } from '../api/apiConfig';
 
 export const sendLog = async (logData: LogData): Promise<void> => {
   try {
-    const response = await fetchWithTimeout(`${import.meta.env.VITE_API_BASE_URL}/logs`, {
+    const response = await fetchWithTimeout(`${API_BASE_URL}${LOG_ENDPOINT}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/input-app/src/services/TemplateLoader.ts
+++ b/input-app/src/services/TemplateLoader.ts
@@ -1,10 +1,11 @@
 import type { Template } from '../types/Questionnaire';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+import { API_BASE_URL, TEMPLATE_ENDPOINT } from '../api/apiConfig';
 
 export const fetchTemplate = async (departmentId: string): Promise<Template> => {
   try {
     const response = await fetchWithTimeout(
-      `${import.meta.env.VITE_API_BASE_URL}${import.meta.env.VITE_TEMPLATE_ENDPOINT}/${departmentId}`,
+      `${API_BASE_URL}${TEMPLATE_ENDPOINT}/${departmentId}`,
     );
     if (!response.ok) {
       const errorBody = await response.text();

--- a/input-app/src/services/apiConfig.ts
+++ b/input-app/src/services/apiConfig.ts
@@ -1,4 +1,0 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-export const KEY_ENDPOINT = import.meta.env.VITE_KEY_ENDPOINT;
-export const TEMPLATE_ENDPOINT = import.meta.env.VITE_TEMPLATE_ENDPOINT;
-export const LOG_ENDPOINT = import.meta.env.VITE_LOGS_ENDPOINT;


### PR DESCRIPTION
## Summary
- add `src/api/apiConfig.ts` to expose backend endpoints
- update services to use the shared API config
- remove old `apiConfig` file from services

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68688c4205208323b440ef2c613a44b5