### PR TITLE
Remove legacy middleware logs

### DIFF
--- a/input-app/vite.config.ts
+++ b/input-app/vite.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-console.log('[Vite Config] Loading vite.config.ts')
-
 const mockApiPlugin = () => ({
   name: 'mock-api',
   configureServer(server) {
-    console.log('[Vite Config] configureServer hook called.')
     server.middlewares.use((req, res, next) => {
-      console.log('[Mock API] Hit: ' + req.url)
       if (req.url?.startsWith('/api/templates/')) {
         res.setHeader('Content-Type', 'application/json')
         res.end(JSON.stringify({ template: { id: 1, name: 'Sample' } }))


### PR DESCRIPTION
## Summary
- remove console.log debug logs from vite config for clean plugin usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868937f33b88323b4f9875342b07f69