### PR TITLE
Align dev mock API with Azure routing

### DIFF
--- a/input-app/.env.example
+++ b/input-app/.env.example
@@ -1,14 +1,14 @@
 # Base URL for all API calls (can be empty for same-origin calls during local dev)
-VITE_API_BASE_URL=https://example.com/api
+VITE_API_BASE_URL=
 
 # Endpoint path for public key retrieval API
-VITE_KEY_ENDPOINT=/public-key
+VITE_KEY_ENDPOINT=/api/public-key
 
 # Endpoint path for questionnaire template fetch API
-VITE_TEMPLATE_ENDPOINT=/templates
+VITE_TEMPLATE_ENDPOINT=/api/templates
 
 # Endpoint path for client log submission API
-VITE_LOGS_ENDPOINT=/logs
+VITE_LOGS_ENDPOINT=/api/logs
 
 # Timeout for API requests in milliseconds
 VITE_REQUEST_TIMEOUT_MS=5000

--- a/input-app/mock/azure/mockApiPlugin.ts
+++ b/input-app/mock/azure/mockApiPlugin.ts
@@ -1,0 +1,63 @@
+// Vite plugin providing mock API routes emulating Azure Functions behavior
+// Each route corresponds to an Azure Function that will exist in production.
+
+import type { Plugin } from 'vite'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export const mockAzureApiPlugin = (): Plugin => ({
+  name: 'vite-plugin-mock-azure-api',
+  async configureServer(server) {
+    server.middlewares.use(async (req, res, next) => {
+      if (!req.url) {
+        return next()
+      }
+
+      // Azure Functions の GetPublicKey に対応
+      if (req.method === 'GET' && req.url === '/api/public-key') {
+        res.setHeader('Content-Type', 'application/json')
+        res.setHeader('Access-Control-Allow-Origin', '*')
+        res.end(
+          JSON.stringify({
+            public_key:
+              '-----BEGIN PUBLIC KEY-----\nFAKEKEY123...\n-----END PUBLIC KEY-----',
+          }),
+        )
+        return
+      }
+
+      // Azure Functions の GetTemplate に対応
+      if (req.method === 'GET' && req.url.startsWith('/api/templates/')) {
+        const id = req.url.split('/').pop() || ''
+        const templatePath = path.resolve(
+          __dirname,
+          `../../../functions/src/templates/template_${id}.json`,
+        )
+        try {
+          const data = await fs.readFile(templatePath, 'utf-8')
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Access-Control-Allow-Origin', '*')
+          res.end(JSON.stringify({ template: JSON.parse(data) }))
+        } catch {
+          res.statusCode = 404
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Access-Control-Allow-Origin', '*')
+          res.end(JSON.stringify({ error: 'Template not found' }))
+        }
+        return
+      }
+
+      // Azure Functions の SendLog に対応
+      if (req.method === 'POST' && req.url === '/api/logs') {
+        res.statusCode = 204
+        res.setHeader('Access-Control-Allow-Origin', '*')
+        res.end()
+        return
+      }
+
+      next()
+    })
+  },
+})
+
+export default mockAzureApiPlugin

--- a/input-app/vite.config.ts
+++ b/input-app/vite.config.ts
@@ -1,22 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-
-const mockApiPlugin = () => ({
-  name: 'mock-api',
-  configureServer(server) {
-    server.middlewares.use((req, res, next) => {
-      if (req.url?.startsWith('/api/templates/')) {
-        res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify({ template: { id: 1, name: 'Sample' } }))
-        return
-      }
-      next()
-    })
-  },
-})
+import mockAzureApiPlugin from './mock/azure/mockApiPlugin'
 
 export default defineConfig({
-  plugins: [react(), mockApiPlugin()],
+  plugins: [react(), mockAzureApiPlugin()],
   server: {
     port: 5174,
   },


### PR DESCRIPTION
## Summary
- restructure Vite mock API middleware into `mock/azure/mockApiPlugin.ts`
- register Azure-style mock plugin from `vite.config.ts`
- default `.env.example` paths to `/api/` routes

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68689a49a4808323bbdcfbe45817dc8d