### PR TITLE
Fix option rendering

### DIFF
--- a/input-app/package-lock.json
+++ b/input-app/package-lock.json
@@ -19,6 +19,7 @@
         "@eslint/js": "^9.29.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/encoding-japanese": "^2.2.1",
+        "@types/node": "^24.0.10",
         "@types/pako": "^2.0.3",
         "@types/qrcode.react": "^1.0.5",
         "@types/react": "^19.1.8",
@@ -1339,6 +1340,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/pako": {
       "version": "2.0.3",
@@ -3565,6 +3576,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/input-app/package.json
+++ b/input-app/package.json
@@ -21,6 +21,7 @@
     "@eslint/js": "^9.29.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/encoding-japanese": "^2.2.1",
+    "@types/node": "^24.0.10",
     "@types/pako": "^2.0.3",
     "@types/qrcode.react": "^1.0.5",
     "@types/react": "^19.1.8",

--- a/input-app/src/components/StepConfirm.tsx
+++ b/input-app/src/components/StepConfirm.tsx
@@ -29,11 +29,31 @@ export const StepConfirm = ({ template, answers, onConfirm, onBack }: Props) => 
     }
   }, [answers, template])
 
-  const getDisplayValue = (q: Question, value: FormState['answers'][string]): string => {
+  const getDisplayValue = (
+    q: Question,
+    value: FormState['answers'][string],
+  ): string => {
     if (value === undefined || value === null) return ''
-    if (Array.isArray(value)) return value.join(', ')
+    if (q.type === 'select' && (typeof value === 'string' || typeof value === 'number')) {
+      return (
+        q.options?.find((opt) => String(opt.id) === String(value))?.label ?? String(value)
+      )
+    }
+    if (Array.isArray(value)) {
+      return (
+        q.options
+          ?.filter((opt) => value.includes(String(opt.id)))
+          .map((opt) => opt.label)
+          .join(', ') ?? value.join(', ')
+      )
+    }
     if (q.type === 'multi_select' && q.bitflag && typeof value === 'number') {
-      return q.options?.filter((_, index) => (value & (1 << index)) !== 0).join(', ') || ''
+      return (
+        q.options
+          ?.filter((opt) => (value & Number(opt.id)) !== 0)
+          .map((opt) => opt.label)
+          .join(', ') ?? ''
+      )
     }
     if (typeof value === 'object') return '' // coordinateは別途処理
     return String(value)
@@ -65,11 +85,11 @@ export const StepConfirm = ({ template, answers, onConfirm, onBack }: Props) => 
               const c = value as Coordinate
               return (
                 <li key={q.id} className="my-2">
-                  <div><strong>{q.text}:</strong></div>
+                  <div><strong>{q.label}:</strong></div>
                   <div className="relative w-48 h-48">
                     <img
                       src={q.image || '/vite.svg'}
-                      alt={q.text}
+                      alt={q.label}
                       className="w-full h-full"
                     />
                     <div
@@ -87,7 +107,7 @@ export const StepConfirm = ({ template, answers, onConfirm, onBack }: Props) => 
             }
             return (
               <li key={q.id} className="my-2">
-                <strong>{q.text}:</strong> {getDisplayValue(q, value)}
+                <strong>{q.label}:</strong> {getDisplayValue(q, value)}
               </li>
             )
           })}

--- a/input-app/src/components/StepPainLocation.tsx
+++ b/input-app/src/components/StepPainLocation.tsx
@@ -21,7 +21,7 @@ export const StepPainLocation = ({ question, value, onChange }: Props) => {
     <div className="relative" ref={containerRef}>
       <img
         src={question.image || '/vite.svg'}
-        alt={question.text}
+        alt={question.label}
         onClick={handleClick}
         className="w-full max-w-xs mx-auto"
       />

--- a/input-app/src/components/StepQuestionnaire.tsx
+++ b/input-app/src/components/StepQuestionnaire.tsx
@@ -132,14 +132,18 @@ export const StepQuestionnaire = ({ template, answers, onAnswer, onNext, onBack 
               {q.label} {q.required && <span className="text-red-500">*</span>}
             </label>
             <select
-              value={typeof answers[q.id] === 'string' || typeof answers[q.id] === 'number' ? (answers[q.id] as string | number) : ''}
+              value={
+                typeof answers[q.id] === 'string' || typeof answers[q.id] === 'number'
+                  ? (answers[q.id] as string | number)
+                  : ''
+              }
               onChange={(e) => onAnswer(q.id, e.target.value)}
               className={common}
             >
               <option value="">選択してください</option>
               {q.options?.map((option) => (
-                <option key={option} value={option}>
-                  {option}
+                <option key={option.id} value={option.id}>
+                  {option.label}
                 </option>
               ))}
             </select>
@@ -152,36 +156,38 @@ export const StepQuestionnaire = ({ template, answers, onAnswer, onNext, onBack 
             <label className="block mb-1">
               {q.label} {q.required && <span className="text-red-500">*</span>}
             </label>
-            {q.options?.map((option, index) => (
-              <div key={option} className="flex items-center">
+            {q.options?.map((option) => (
+              <div key={option.id} className="flex items-center">
                 <input
                   type="checkbox"
-                  id={`${q.id}-${index}`}
-                  value={option}
+                  id={`${q.id}-${option.id}`}
+                  value={option.id}
                   checked={
                     q.bitflag
-                      ? ((typeof answers[q.id] === 'number' ? (answers[q.id] as number) : 0) & (1 << index)) !== 0
-                      : Array.isArray(answers[q.id]) && (answers[q.id] as string[]).includes(option)
+                      ? ((typeof answers[q.id] === 'number' ? (answers[q.id] as number) : 0) & Number(option.id)) !== 0
+                      : Array.isArray(answers[q.id]) && (answers[q.id] as string[]).includes(String(option.id))
                   }
                   onChange={(e) => {
                     if (q.bitflag) {
                       let cur: number = typeof answers[q.id] === 'number' ? (answers[q.id] as number) : 0
+                      const bit = Number(option.id)
                       if (e.target.checked) {
-                        cur |= 1 << index
+                        cur |= bit
                       } else {
-                        cur &= ~(1 << index)
+                        cur &= ~bit
                       }
                       onAnswer(q.id, cur)
                     } else {
                       let cur: string[] = Array.isArray(answers[q.id]) ? (answers[q.id] as string[]) : []
-                      if (e.target.checked) cur = [...cur, option]
-                      else cur = cur.filter((it) => it !== option)
+                      const idStr = String(option.id)
+                      if (e.target.checked) cur = [...cur, idStr]
+                      else cur = cur.filter((it) => it !== idStr)
                       onAnswer(q.id, cur)
                     }
                   }}
                   className="mr-2"
                 />
-                <label htmlFor={`${q.id}-${index}`}>{option}</label>
+                <label htmlFor={`${q.id}-${option.id}`}>{option.label}</label>
               </div>
             ))}
             {error && <p className="text-red-500 text-sm">{error}</p>}
@@ -206,7 +212,7 @@ export const StepQuestionnaire = ({ template, answers, onAnswer, onNext, onBack 
       default:
         return (
           <div key={q.id} className="mb-4">
-            {q.text} (未実装)
+            {q.label} (未実装)
           </div>
         )
     }

--- a/input-app/src/types/Questionnaire.ts
+++ b/input-app/src/types/Questionnaire.ts
@@ -3,9 +3,14 @@ export interface Coordinate {
   y: number;
 }
 
+export interface Option {
+  id: string | number
+  label: string
+}
+
 export interface Question {
-  id: string;
-  text: string;
+  id: string
+  label: string
   type:
     | 'text'
     | 'textarea'
@@ -13,8 +18,8 @@ export interface Question {
     | 'date'
     | 'select'
     | 'multi_select'
-    | 'coordinate';
-  options?: string[];
+    | 'coordinate'
+  options?: Option[]
   image?: string; // for coordinate questions
   required?: boolean;
   maxLength?: number;


### PR DESCRIPTION
## Summary
- use `Option` objects for questionnaire options
- show option labels in Questionnaires
- display option text in confirmations
- use question `label` field throughout
- add `@types/node` to compile mock plugin

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868aa0c6dfc8323b149fc0407e18067