### PR TITLE
Update public key endpoint

### DIFF
--- a/input-app/mock/azure/mockApiPlugin.ts
+++ b/input-app/mock/azure/mockApiPlugin.ts
@@ -15,14 +15,23 @@ export const mockAzureApiPlugin = (): Plugin => ({
 
       // このエンドポイントは Azure Functions の GetPublicKey に対応
       if (req.method === 'GET' && req.url === '/api/public-key') {
-        res.setHeader('Content-Type', 'application/json')
-        res.setHeader('Access-Control-Allow-Origin', '*')
-        res.end(
-          JSON.stringify({
-            public_key:
-              '-----BEGIN PUBLIC KEY-----\nFAKEKEY123...\n-----END PUBLIC KEY-----',
-          }),
+        const keyPath = path.resolve(
+          __dirname,
+          '../azurevaultkey/public.pem',
         )
+        try {
+          const publicKey = await fs.readFile(keyPath, 'utf-8')
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Access-Control-Allow-Origin', '*')
+          res.end(JSON.stringify({ public_key: publicKey }))
+        } catch {
+          res.statusCode = 500
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Access-Control-Allow-Origin', '*')
+          res.end(
+            JSON.stringify({ error: 'Failed to load public key' }),
+          )
+        }
         return
       }
 


### PR DESCRIPTION
## Summary
- read public key from `mock/azurevaultkey/public.pem` in mock plugin

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868bba6bd248323a81de045b6948d8e