### PR TITLE
Move mock public key to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ dist/
 # Log files
 *.log
 
+# Local mock API public key
+mock/azurevaultkey/public.pem
+
 # Ignore mistakenly generated root package-lock
 /package-lock.json

--- a/input-app/mock/azure/mockApiPlugin.ts
+++ b/input-app/mock/azure/mockApiPlugin.ts
@@ -17,7 +17,7 @@ export const mockAzureApiPlugin = (): Plugin => ({
       if (req.method === 'GET' && req.url === '/api/public-key') {
         const keyPath = path.resolve(
           __dirname,
-          '../azurevaultkey/public.pem',
+          '../../../mock/azurevaultkey/public.pem',
         )
         try {
           const publicKey = await fs.readFile(keyPath, 'utf-8')


### PR DESCRIPTION
## Summary
- relocate mock API key reading path
- ignore public key file at new location

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868bf3c12fc8323b0d984f17d886cdf